### PR TITLE
Fix _make helper function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -251,12 +251,12 @@ _gen_kern_name() {
     if [[ "$_modprobeddb" == "true" || "$_kernel_on_diet" == "true" ]]; then
       msg2 "Building modprobed/diet kernel..."
       {
-        time (env ${compiler_opt} make "${verbose_opt}" LSMOD="$_modprobeddb_db_path" localmodconfig -j${_thread_num} "$@")
+        time (env ${compiler_opt} make ${verbose_opt} LSMOD="$_modprobeddb_db_path" localmodconfig -j${_thread_num:-1} "$@")
       } 3>&1 1>&2 2>&3
     else
       msg2 "Building kernel..."
       {
-        time (env ${compiler_opt} make "${verbose_opt}" -j${_thread_num} "$@")
+        time (env ${compiler_opt} make ${verbose_opt} -j${_thread_num:-1} "$@")
       } 3>&1 1>&2 2>&3
     fi
     }


### PR DESCRIPTION
The make command should avoid empty strings as arguments.
So any parameters passed as arguments should not have double quotes around them unless they have a fallback value.
E.g. `${option1} "${option2:-something}"`